### PR TITLE
Add genomeList to igvConfig so custom genome ids are recognized.

### DIFF
--- a/igvwebConfig.js
+++ b/igvwebConfig.js
@@ -14,6 +14,7 @@ var igvwebConfig = {
 
     igvConfig:
         {
+            genomeList: "resources/genomes.json",
             queryParametersSupported: true,
             showChromosomeWidget: true,
             showSVGButton: false,


### PR DESCRIPTION
Note that this duplicates the configuration value of `genomes` from the outer igvwebConfig.