### PR TITLE
Fix: Overenthusiastic track removal in trackSelectionModal

### DIFF
--- a/js/widgets/trackSelectionModal.js
+++ b/js/widgets/trackSelectionModal.js
@@ -104,16 +104,23 @@ export default function createTrackSelectionModal({id, label = '', sections, des
     modalElement.addEventListener('hidden.bs.modal', () => {
         if (modalAction === 'ok') {
             console.log('Modal closed with OK button')
-            const checkboxes = Array.from(modalElement.querySelectorAll('input[type="checkbox"]:checked'))
+            const checkedCheckboxes = Array.from(modalElement.querySelectorAll('input[type="checkbox"]:checked'))
             const checkedTracks =
-                checkboxes
+                checkedCheckboxes
+                    .map(checkbox => {
+                        const trackConfig = trackMap.get(checkbox.id)
+                        return trackConfig
+                    })
+            const uncheckedCheckboxes = Array.from(modalElement.querySelectorAll('input[type="checkbox"]:not(:checked)'))
+            const uncheckedTracks =
+                uncheckedCheckboxes
                     .map(checkbox => {
                         const trackConfig = trackMap.get(checkbox.id)
                         return trackConfig
                     })
 
             if (okHandler) {
-                okHandler(checkedTracks)
+                okHandler(checkedTracks, uncheckedTracks)
             } else {
                 console.log('URLs of checked tracks:', checkedTracks)
             }

--- a/js/widgets/trackWidgets.js
+++ b/js/widgets/trackWidgets.js
@@ -205,16 +205,17 @@ async function trackMenuGenomeChange(browser, genome) {
                             annotateTracks(group)
                         }
 
-                        config.okHandler = (selections) => {
+                        config.okHandler = (checkedTracks, uncheckedTracks) => {
 
-                            const checkedURLs = new Set(selections.map(s => s.url))
-                            const toUnload = new Set(Array.from(loadedURLs).filter(url => !checkedURLs.has(url)))
+                            const checkedURLs = new Set(checkedTracks.map(s => s.url))
+                            const uncheckedURLs = new Set(uncheckedTracks.map(s => s.url))
+                            const toUnload = new Set(Array.from(loadedURLs).filter(url => !checkedURLs.has(url) && uncheckedURLs.has(url)))
                             const tracksToUnload = browser.findTracks(track => track.url && toUnload.has(track.url))
                             for (let t of tracksToUnload) {
                                 browser.removeTrack(t)
                             }
 
-                            const trackConfigs = selections.filter(config => !loadedURLs.has(config.url))
+                            const trackConfigs = checkedTracks.filter(config => !loadedURLs.has(config.url))
                             if (trackConfigs.length > 0) {
                                 try {
                                     trackLoadHandler(trackConfigs)


### PR DESCRIPTION
When clicking OK in trackSelectionModal, all tracks in the browser that are not selected are removed, including those that are not present in the modal. To replicate: Add any track from "GTEx Single Tissue EQTLS" and press OK. The default RefSeq Select track will be removed, even though it wasn't one of the options in GTEx Single Tissue EQTLS. 

This PR adds the unchecked tracks as an argument to okHandler, and uses them to remove only tracks that are available to choose from.